### PR TITLE
fix: set-workspace does not work correctly without cursor-warp

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 wlroots-based Wayland compositor with virtual outputs and physical cursor continuity.
 Originally forked from dwl.
 
-`LOC: 7442 total, 2878 vwl.c`
+`LOC: 7444 total, 2880 vwl.c`
 
 ## Features
 

--- a/vwl.c
+++ b/vwl.c
@@ -2714,7 +2714,9 @@ view(const Arg *arg)
 		return;
 	vout = ws->vout;
 	if (!vout) {
-		if (cursor) {
+		if (!enable_cursor_warp_to_vout && selvout) {
+			vout = selvout;
+		} else if (cursor) {
 			Monitor *pointer_mon = xytomon(cursor->x, cursor->y);
 			VirtualOutput *pointer_vout = pointer_mon ? voutat(pointer_mon, cursor->x, cursor->y) : NULL;
 			if (pointer_vout)


### PR DESCRIPTION
This one was haunting me now for a while until I `bisect`ed it today:

When cursor warping is disabled a combination of `vwlctl set-vout-focus` + `vwlctl set-workspace` did not load that workspace on the then focused `vout` but instead on the `vout` under the mouse cursor (which might be still somewhere else).

Adding the `if` below favors a set `selvout` over the cursor position if cursor-warping is disabled.